### PR TITLE
bundler needs to be a runtime dependency, otherwise you get an error

### DIFF
--- a/rb2exe.gemspec
+++ b/rb2exe.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.executables << 'rb2exe'
 
-  spec.add_development_dependency 'bundler', '~> 1.12'
+  spec.add_runtime_dependency 'bundler', '~> 1.12'
   spec.add_development_dependency 'rake', '~> 10.0'
 end


### PR DESCRIPTION
if you dont have bundler installed on your system, and you try running `rb2exe somefile.rb` you will get an error. to prevent this from happening, you can ensure that the user has bundler installed by assigning it as a runtime dependency